### PR TITLE
#1 ゲーム内で翻訳機能の有効無効を切り替えられるコマンドを追加した。 コンフィグファイルからも起動時に有効化するか設定可能に

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,30 +51,29 @@ bukkit {
     author = "ft"
     prefix = "CDT"
 
-    /*
+
     commands {
-        register("command") {
-            description = "Just a command!"
-            aliases = listOf("cmd")
-            permission = "command.children"
-            usage = "/command"
-            permissionMessage = "no perm"
+        register("deeplchattranslator") {
+            description = "main command of Deepl chat translator"
+            aliases = listOf("dct")
+            permission = "dct.command.deeplchattranslator"
+            usage = "/dct"
+            permissionMessage = "No permission"
         }
     }
 
 
     permissions {
-        register("command.*") {
-            children = listOf("ktt.children")
-
+        register("dct.*") {
+            children = listOf("dct.command.deeplchattranslator")
         }
 
-        register("command.children") {
-            description = "the childlen command"
+        register("dct.command.deeplchattranslator") {
+            description = "Permission node for Deepl chat translator main command"
             default = BukkitPluginDescription.Permission.Default.OP
         }
     }
-    */
+
 }
 
 

--- a/src/main/kotlin/commands/MainCommand.kt
+++ b/src/main/kotlin/commands/MainCommand.kt
@@ -1,0 +1,50 @@
+package jp.faketuna.paper.deeplchattranslator.commands
+
+import jp.faketuna.paper.deeplchattranslator.DeeplChatTranslator
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+
+class MainCommand: CommandExecutor {
+
+    private val prefix = DeeplChatTranslator.PluginManager.getPluginPrefix()
+    private val pluginManager = DeeplChatTranslator.PluginManager
+    
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>?): Boolean {
+        if (args!!.isEmpty()){
+            sender.sendMessage("USAGE")
+            return true
+        }
+
+        if(command.name.equals("deeplchattranslator", ignoreCase = true)){
+            if(args[0].equals("version", ignoreCase = true)){
+                sender.sendMessage("$prefix This server is currently running version ${DeeplChatTranslator.PluginManager.getPluginVerison()}")
+            }
+
+            if(args[0].equals("toggle", ignoreCase = true)){
+                pluginManager.setTranslationState(!pluginManager.getTranslationState())
+                sender.sendMessage("$prefix Plugin chat translation is now ${pluginManager.getTranslationState()}.")
+            }
+
+            if(args[0].equals("enable", ignoreCase = true)){
+                if (pluginManager.getTranslationState()){
+                    sender.sendMessage("$prefix Chat translation is already enabled!")
+                    return true
+                }
+                pluginManager.setTranslationState(true)
+                sender.sendMessage("$prefix Enabled chat translation")
+            }
+
+            if(args[0].equals("disable", ignoreCase = true)){
+                if (!pluginManager.getTranslationState()){
+                    sender.sendMessage("$prefix Chat translation is already disabled!")
+                    return true
+                }
+                pluginManager.setTranslationState(false)
+                sender.sendMessage("$prefix Disabled chat translation")
+            }
+            return true
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/commands/MainCommandTabCompleter.kt
+++ b/src/main/kotlin/commands/MainCommandTabCompleter.kt
@@ -1,0 +1,19 @@
+package jp.faketuna.paper.deeplchattranslator.commands
+
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+
+class MainCommandTabCompleter: TabCompleter {
+    override fun onTabComplete(sender: CommandSender, command: Command, label: String, args: Array<out String>?): MutableList<String>? {
+        if(command.name.equals("deeplchattranslator", ignoreCase = true ) && args!!.size == 1){
+            val list = mutableListOf<String>()
+            list.add("version")
+            list.add("toggle")
+            list.add("enable")
+            list.add("disable")
+            return list
+        }
+        return null
+    }
+}

--- a/src/main/resources/key.yml
+++ b/src/main/resources/key.yml
@@ -1,1 +1,0 @@
-apiKey: Your key


### PR DESCRIPTION
コマンド
deeplchattranslatorコマンド(省略形 dct)を追加
deeplchattranslator用にTab completerを追加

コンフィグ
コンフィグファイル名をkey.ymlからconfig.ymlに変更し新たにenabledキーを追加。